### PR TITLE
DefWndProc returns true for WM_QUERYENDSESSION

### DIFF
--- a/mono/mcs/class/System.Windows.Forms/System.Windows.Forms.CocoaInternal/XplatUICocoa.cs
+++ b/mono/mcs/class/System.Windows.Forms/System.Windows.Forms.CocoaInternal/XplatUICocoa.cs
@@ -1082,6 +1082,9 @@ namespace System.Windows.Forms {
 				}
 				case Msg.WM_MOUSEACTIVATE:
 					return new IntPtr((int)MouseActivate.MA_ACTIVATE); // Shoudn't we send it to the parent?
+
+				case Msg.WM_QUERYENDSESSION:
+					return new IntPtr(1);
 			}
 			return IntPtr.Zero;
 		}


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/desktop/shutdown/wm-queryendsession:

Return value
Applications should respect the user's intentions and return TRUE. By default, the DefWindowProc function returns TRUE for this message.

I discovered this when working with code that did not clean up all windows properly. `WM_QUERYENDSESSION` from `ApplicationShouldTerminate` bubbled up to `DefWndProc` which responded with `IntPtr.Zero` thereby canceling the shutdown.