### PR TITLE
Do not focus tooltip windows

### DIFF
--- a/mono/mcs/class/System.Windows.Forms/System.Windows.Forms.CocoaInternal/XplatUICocoa.cs
+++ b/mono/mcs/class/System.Windows.Forms/System.Windows.Forms.CocoaInternal/XplatUICocoa.cs
@@ -1960,6 +1960,8 @@ namespace System.Windows.Forms {
 						monoWindow.Owner.AddChildWindow(winWrap, NSWindowOrderingMode.Above);
 					if (Control.FromHandle(handle).ActivateOnShow)
 						winWrap.MakeKeyAndOrderFront(winWrap);
+					else if (winWrap.IgnoresMouseEvents)
+						winWrap.OrderFront(winWrap);
 					else
 						winWrap.IsVisible = true;
 				} else {


### PR DESCRIPTION
I noticed that the active window loses its focus when a tooltip is shown. This changs resolves the behavior since tooltips are initialized with `Window.IgnoresMouseEvents = true`