### PR TITLE
Show popup on main window's ContentView to inherit color settings

### DIFF
--- a/mono/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripDropDown.cs
+++ b/mono/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripDropDown.cs
@@ -566,9 +566,9 @@ namespace System.Windows.Forms
 				((MonoMenuDelegate)currentMenu.Delegate).BeforePopup ();
 				show_point = CalculateShowPoint (position, direction, new Size((int)currentMenu.Size.Width, (int)currentMenu.Size.Height));
 				NSApplication.SharedApplication.BeginInvokeOnMainThread(delegate {
-					Size displaySize;
-					XplatUI.GetDisplaySize(out displaySize);
-					currentMenu.PopUpMenu(null, new CGPoint(show_point.X, displaySize.Height - show_point.Y), null);
+					var mainWindow = NSApplication.SharedApplication.MainWindow;
+					var winPosition = mainWindow.ConvertPointFromScreen(new CGPoint(show_point.X, show_point.Y));
+					currentMenu.PopUpMenu(null, winPosition, mainWindow.ContentView);
 				});
 			}
 


### PR DESCRIPTION
Related to https://github.com/filipnavara/mac-playground/issues/1 it seems like with this change the popup menu uses the expected system colors also in dark mode